### PR TITLE
Ruby 1.8 compatibility

### DIFF
--- a/app/views/application/_flashes.html.haml
+++ b/app/views/application/_flashes.html.haml
@@ -1,5 +1,5 @@
 #flash
   - flash.each do |key, value|
     .wrapper
-      %div{ title: key.to_s.humanize, class: key }
+      %div{ :title => key.to_s.humanize, :class => key }
         %p= value

--- a/app/views/application/_head.html.haml
+++ b/app/views/application/_head.html.haml
@@ -1,9 +1,9 @@
 %meta{ :charset => "utf-8" }/
 
-/ Use the .htaccess and remove these lines to avoid edge case issues.
+-# Use the .htaccess and remove these lines to avoid edge case issues.
 %meta{ 'http-equiv' => 'X-UA-Compatible', :content => 'IE=edge,chrome=1' }/
 
-/ Mobile viewport optimized: j.mp/bplateviewport
+-# Mobile viewport optimized: j.mp/bplateviewport
 %meta{ :name => "viewport", :content => "width=device-width,initial-scale=1" }/
 
 %title

--- a/app/views/application/_head.html.haml
+++ b/app/views/application/_head.html.haml
@@ -1,16 +1,16 @@
-%meta{ charset: "utf-8" }/
+%meta{ :charset => "utf-8" }/
 
--# Use the .htaccess and remove these lines to avoid edge case issues.
-%meta{ "http-equiv" => "X-UA-Compatible", content: "IE=edge,chrome=1" }/
+/ Use the .htaccess and remove these lines to avoid edge case issues.
+%meta{ 'http-equiv' => 'X-UA-Compatible', :content => 'IE=edge,chrome=1' }/
 
--# Mobile viewport optimized: j.mp/bplateviewport
-%meta{ name: "viewport", content: "width=device-width,initial-scale=1" }/
+/ Mobile viewport optimized: j.mp/bplateviewport
+%meta{ :name => "viewport", :content => "width=device-width,initial-scale=1" }/
 
 %title
   == #{ controller.controller_name.titleize } - #{ controller.action_name.titleize }
-  
-%meta{ name: "description", content: "" }/
-%meta{ name: "author", content: "" }/
+
+%meta{ :name => "description", :content => "" }/
+%meta{ :name => "author", :content => "" }/
 
 -# Place favicon.ico and apple-touch-icon.png in the root directory: mathiasbynens.be/notes/touch-icons
 

--- a/app/views/application/_javascripts.html.haml
+++ b/app/views/application/_javascripts.html.haml
@@ -1,5 +1,5 @@
 = javascript_include_tag "application"
-    
+
 -#  Append your own using content_for :javascripts
 = yield :javascripts
 
@@ -15,5 +15,5 @@
 -# Prompt IE 6 users to install Chrome Frame. Remove this if you want to support IE 6.
 -# chromium.org/developers/how-tos/chrome-frame-getting-started
 /[if lt IE 7 ]
-  %script{ defer: true, src: "//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js" }
-  %script{ defer: true } window.attachEvent('onload',function(){CFInstall.check({mode:'overlay'})})
+  %script{ :defer => true, :src => "//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js" }
+  %script{ :defer => true } window.attachEvent('onload',function(){CFInstall.check({mode:'overlay'})})

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!! 5
--# http://paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither
+/ http://paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither
 -ie_html :class => "no-js", :lang => "en" do
   %head
     = render "head"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,11 +4,11 @@
   %head
     = render "head"
 
-  %body{ class: "#{ controller.controller_name }" }
+  %body{ :class => "#{ controller.controller_name }" }
     %header#header
       = render "header"
 
-    #main{ role: "main" }
+    #main{ :role => "main" }
       = render "flashes"
       = yield
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,19 +1,19 @@
 !!! 5
 -# http://paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither
--ie_html class: "no-js", lang: "en" do
+-ie_html :class => "no-js", :lang => "en" do
   %head
     = render "head"
-  
+
   %body{ class: "#{ controller.controller_name }" }
     %header#header
       = render "header"
-      
+
     #main{ role: "main" }
       = render "flashes"
       = yield
-      
+
     %footer#footer
       = render "footer"
-        
+
     -# Javascript at the bottom for fast page loading
     = render "javascripts"

--- a/lib/generators/html5/layout/layout_generator.rb
+++ b/lib/generators/html5/layout/layout_generator.rb
@@ -3,20 +3,20 @@ module Html5
     class LayoutGenerator < ::Rails::Generators::Base
       source_root File.expand_path('../../../../../app/views', __FILE__)
 
-      argument :name, type: :string,
-                      required: false,
-                      default: "application",
-                      desc: "The layout name"
-                      
-      class_option :partials, type: :boolean, 
-                              default: false,
-                              desc: "Generate partials"
+      argument :name, :type => :string,
+                      :required => false,
+                      :default => "application",
+                      :desc => "The layout name"
+
+      class_option :partials, :type => :boolean,
+                              :default => false,
+                              :desc => "Generate partials"
 
       def generate_layout
         remove_file "app/views/layouts/#{ name.underscore }.html.erb"
         copy_file "layouts/application.html.haml", "app/views/layouts/#{ name.underscore }.html.haml"
       end
-      
+
       def copy_partials
         puts "OPTIONS #{options.inspect}"
         if options.partials?


### PR DESCRIPTION
Replace new 1.9 hash syntax by the classical one. 
Example : 

{class: "no-js", lang: "en"} by {:class => "no-js", :lang => "en"}
