### PR TITLE
Allow use with Rails 3.2

### DIFF
--- a/html5-rails.gemspec
+++ b/html5-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "html5-rails"
 
   s.add_dependency "jquery-rails",  "~> 1.0.19"
-  s.add_dependency "railties",      "~> 3.1.0"
+  s.add_dependency "railties",      "~> 3.1"
   s.add_dependency "thor",          "~> 0.14"
 
   s.add_development_dependency "compass-h5bp", "~> 0.0.1"


### PR DESCRIPTION
I relaxed the dependency on Rails 3.1.0 to allow use with 3.2
