### PR TITLE
Change dependency to be able to use this gem with jquery-rails 2.0.0

### DIFF
--- a/html5-rails.gemspec
+++ b/html5-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "html5-rails"
 
-  s.add_dependency "jquery-rails",  "~> 1.0.19"
+  s.add_dependency "jquery-rails",  ">= 1.0.19"
   s.add_dependency "railties",      "~> 3.1"
   s.add_dependency "thor",          "~> 0.14"
 


### PR DESCRIPTION
Wanted to use this gem with a fresh rails 3.2 app where jquery-rails is installed as 2.0.0
