### PR TITLE
allow jquery-rails >= 1.0.19, including 2.X.X

### DIFF
--- a/html5-rails.gemspec
+++ b/html5-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "html5-rails"
 
-  s.add_dependency "jquery-rails",  "~> 1.0.19"
+  s.add_dependency "jquery-rails",  ">= 1.0.19"
   s.add_dependency "railties",      "~> 3.1"
   s.add_dependency "thor",          "~> 0.14"
 


### PR DESCRIPTION
Rails 3.2 is out since a week or so, and depends on jquery-rails 2.0.0 (afaik the rc versions were fine with jquery-rails 1.0.X). So html5-rails depending on jquery-rails 1.0.X breaks Rails 3.2 compatibility. So please pull this patch to reestablish Rails 3.2 compatibility. A newly released would also be nice, so that we don't have to depend on the Github repository :)
