### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ group :assets do
   gem 'sass-rails'
   gem 'coffee-rails'
   gem 'uglifier'
-  gem 'compass', '0.12.alpha.4'
+  gem 'compass-rails'
   gem 'compass-h5bp'
 end
 


### PR DESCRIPTION
Since Compass v0.12, gem "compass-rails" is the only way to install compass into a rails application. 

See https://github.com/Compass/compass-rails
