### PR TITLE
change asset layout to avoid name alias resolution

### DIFF
--- a/lib/generators/html5/assets/assets_generator.rb
+++ b/lib/generators/html5/assets/assets_generator.rb
@@ -34,6 +34,7 @@ module Html5
 
         if file_path == 'application'
           remove_file File.join(prefix, 'application.css')
+          append_file File.join(prefix, 'application.css.scss'),"@import 'application/index'"
         end
 
         if stylesheets.any?


### PR DESCRIPTION
Sprockets 2.3 only allows fixed path because only a static manifest mapping is available in rails production mode
